### PR TITLE
광고 기능 추가

### DIFF
--- a/src/components/Ad.vue
+++ b/src/components/Ad.vue
@@ -1,16 +1,28 @@
 <template>
   <div class="ad">
-    This is ad component
+    <div class="ad__header">sponsored</div>
+    <div class="ad__body">
+      <img class="ad__img" :src="imgUrl" />
+      <div class="ad__title">{{ title }}</div>
+      <div class="ad__contents">{{ contents }}</div>
+    </div>
   </div>
 </template>
 
 <script>
+import { IMG_BASE_URL } from '../constant';
+
 export default {
   name: 'Ad',
   props: {
     title: String,
     contents: String,
     img: String
+  },
+  computed: {
+    imgUrl() {
+      return `${IMG_BASE_URL}/${this.img}`;
+    }
   }
 };
 </script>
@@ -18,5 +30,57 @@ export default {
 <style lang="scss" scoped>
 .ad {
   background-color: #ffffff;
+}
+
+.ad__header {
+  font-size: 13px;
+  line-height: 1.92;
+  color: #adb5bd;
+  margin-bottom: 15.5px;
+}
+
+.ad__img {
+  float: left;
+  width: 310px;
+  height: 179px;
+  background: #ccc;
+  margin: 0 29.5px 0 0;
+
+  @media (max-width: $layout-breakpoint-mobile) {
+    float: none;
+    width: 100%;
+    height: 179px;
+    margin: 0 0 15.5px 0;
+  }
+}
+
+.ad__title {
+  height: 56px;
+  margin-bottom: 10px;
+  white-space: wrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 1.56;
+  color: #282c30;
+
+  @media (max-width: $layout-breakpoint-mobile) {
+    margin-bottom: 5px;
+  }
+}
+
+.ad__contents {
+  height: 100px;
+  white-space: wrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+  line-height: 1.56;
+  color: #495057;
+
+  @media (max-width: $layout-breakpoint-mobile) {
+    height: 50px;
+  }
 }
 </style>

--- a/src/components/Ad.vue
+++ b/src/components/Ad.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="ad">
+    This is ad component
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Ad',
+  props: {
+    title: String,
+    contents: String,
+    img: String
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.ad {
+  background-color: #ffffff;
+}
+</style>

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -43,6 +43,7 @@ export default {
   margin-bottom: 30px;
   padding: 20px 30px;
   background-color: #ffffff;
+  overflow: hidden;
 
   @media (max-width: $layout-breakpoint-mobile) {
     border: none;

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -1,34 +1,36 @@
 <template>
   <div class="card">
-    <div class="card__header">
-      <div class="card__category-id">{{ categoryId }}</div>
-      <div class="card__id">{{ id }}</div>
-    </div>
-    <div class="card__body">
-      <div class="card__info">
-        <div class="card__user-id">{{ userId }}</div>
-        <div class="card__created-at">{{ createdAtFormat }}</div>
-      </div>
-      <div class="card__title">{{ title }}</div>
-      <div class="card__contents">{{ contents }}</div>
-    </div>
+    <Post v-if="isPost" v-bind="data" />
+    <Ad v-else-if="isAd" v-bind="data" />
   </div>
 </template>
 
 <script>
+import Post from './Post';
+import Ad from './Ad';
+import { CardType } from '../constant';
+import { getEnumValues } from '../utils/enum';
+
 export default {
   name: 'Card',
+  components: {
+    Post,
+    Ad
+  },
   props: {
-    id: Number,
-    categoryId: Number,
-    userId: Number,
-    createdAt: String,
-    title: String,
-    contents: String
+    type: {
+      validator(value) {
+        return getEnumValues(CardType).indexOf(value) !== -1;
+      }
+    },
+    data: Object
   },
   computed: {
-    createdAtFormat() {
-      return this.createdAt.substring(0, 10);
+    isPost() {
+      return this.type === CardType.Post;
+    },
+    isAd() {
+      return this.type === CardType.Ad;
     }
   }
 };
@@ -48,73 +50,5 @@ export default {
     box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.05);
     margin-bottom: 10px;
   }
-}
-
-.card__header {
-  padding-bottom: 10px;
-  margin-bottom: 15px;
-  border-bottom: 1px solid $card-border-color;
-  overflow: hidden;
-}
-
-.card__category-id {
-  float: left;
-  color: #7e848a;
-  font-size: 13px;
-  line-height: 1.92;
-}
-
-.card__id {
-  float: right;
-  color: #adb5bd;
-  font-size: 13px;
-  line-height: 1.92;
-}
-
-.card__info {
-  display: flex;
-  margin-bottom: 15px;
-}
-
-.card__user-id {
-  font-size: 13px;
-  line-height: 1.92;
-  color: $main-color;
-  margin-right: 12px;
-}
-.card__created-at {
-  font-size: 13px;
-  line-height: 1.92;
-  color: #495057;
-
-  &::before {
-    content: '|';
-    color: $card-border-color;
-    margin-right: 10px;
-  }
-
-  @media (max-width: $layout-breakpoint-mobile) {
-    display: none;
-  }
-}
-
-.card__title {
-  margin-bottom: 5px;
-  font-size: 18px;
-  font-weight: bold;
-  line-height: 1.56;
-  color: #282c30;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.card__contents {
-  font-size: 16px;
-  line-height: 1.56;
-  color: #495057;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 </style>

--- a/src/components/CardContainer.vue
+++ b/src/components/CardContainer.vue
@@ -13,7 +13,7 @@
 <script>
 import Card from '@/components/Card.vue';
 import InfiniteScroll from '@/components/InfiniteScroll.vue';
-import { mapActions, mapState } from 'vuex';
+import { mapActions, mapGetters, mapState } from 'vuex';
 import { FETCH_CARDS } from '../store/types';
 import { debounce } from '../utils/function';
 import { FETCH_CARD_DELAY } from '../constant';
@@ -25,10 +25,8 @@ export default {
     InfiniteScroll
   },
   computed: {
-    ...mapState({
-      cards: state => state.cards,
-      hasMoreCards: state => state.lastPage >= state.nextPage
-    })
+    ...mapState(['cards']),
+    ...mapGetters(['hasMoreCards'])
   },
   methods: {
     ...mapActions({

--- a/src/components/CardContainer.vue
+++ b/src/components/CardContainer.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="card-container">
-    <Card v-for="card in cards" v-bind="card" :key="card.id" />
+    <Card
+      v-for="card in cards"
+      :key="card.id"
+      :type="card.type"
+      :data="card.data"
+    />
     <InfiniteScroll v-if="hasMoreCards" @load="debouncedFetchCards" />
   </div>
 </template>

--- a/src/components/Post.vue
+++ b/src/components/Post.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="post">
+    <div class="post__header">
+      <div class="post__category-id">{{ categoryId }}</div>
+      <div class="post__id">{{ id }}</div>
+    </div>
+    <div class="post__body">
+      <div class="post__info">
+        <div class="post__user-id">{{ userId }}</div>
+        <div class="post__date">{{ date }}</div>
+      </div>
+      <div class="post__title">{{ title }}</div>
+      <div class="post__contents">{{ contents }}</div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { formatISOString } from '../utils/data';
+
+export default {
+  name: 'Post',
+  props: {
+    id: Number,
+    categoryId: Number,
+    userId: Number,
+    createdAt: String,
+    title: String,
+    contents: String
+  },
+  computed: {
+    date() {
+      return formatISOString(this.createdAt);
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.post {
+  background-color: #ffffff;
+}
+
+.post__header {
+  padding-bottom: 10px;
+  margin-bottom: 15px;
+  border-bottom: 1px solid $card-border-color;
+  overflow: hidden;
+}
+
+.post__category-id {
+  float: left;
+  color: #7e848a;
+  font-size: 13px;
+  line-height: 1.92;
+}
+
+.post__id {
+  float: right;
+  color: #adb5bd;
+  font-size: 13px;
+  line-height: 1.92;
+}
+
+.post__info {
+  display: flex;
+  margin-bottom: 15px;
+}
+
+.post__user-id {
+  font-size: 13px;
+  line-height: 1.92;
+  color: $main-color;
+  margin-right: 12px;
+}
+.post__date {
+  font-size: 13px;
+  line-height: 1.92;
+  color: #495057;
+
+  &::before {
+    content: '|';
+    color: $card-border-color;
+    margin-right: 10px;
+  }
+
+  @media (max-width: $layout-breakpoint-mobile) {
+    display: none;
+  }
+}
+
+.post__title {
+  margin-bottom: 5px;
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 1.56;
+  color: #282c30;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.post__contents {
+  font-size: 16px;
+  line-height: 1.56;
+  color: #495057;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,3 +1,7 @@
 export const API_HOST = 'https://problem.comento.kr';
-export const FETCH_CARD_LENGTH = 10;
 export const FETCH_CARD_DELAY = 300; // 밀리세턴드 단위의 초
+export const FETCH_POST_LENGTH = 10;
+export const CardType = {
+  Post: 'post',
+  Ad: 'ad'
+};

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,6 +1,8 @@
 export const API_HOST = 'https://problem.comento.kr';
 export const FETCH_CARD_DELAY = 300; // 밀리세턴드 단위의 초
 export const FETCH_POST_LENGTH = 10;
+export const FETCH_AD_LENGTH = 10;
+export const AD_INTERVAL = 4; // 얼마 간격으로 광고가 삽입될 지 나타나는 값
 export const CardType = {
   Post: 'post',
   Ad: 'ad'

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,4 +1,5 @@
 export const API_HOST = 'https://problem.comento.kr';
+export const IMG_BASE_URL = 'https://cdn.comento.kr/assignment';
 export const FETCH_CARD_DELAY = 300; // 밀리세턴드 단위의 초
 export const FETCH_POST_LENGTH = 10;
 export const FETCH_AD_LENGTH = 10;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,25 +1,30 @@
 import { createStore } from 'vuex';
 import { callApi } from '../utils/api';
-import { ADD_CARDS, FETCH_CARDS } from './types';
-import { FETCH_CARD_LENGTH } from '../constant';
+import { FETCH_CARDS, FETCH_POSTS, SET_VALUE } from './types';
+import { FETCH_POST_LENGTH } from '../constant';
 import { normalizeObjectProperty } from '@/utils/normalize';
+import { CardType } from '../constant';
+import { makeCard } from '../utils/card';
 
 const state = {
   cards: [],
+  posts: [],
   nextPage: 1,
   lastPage: Infinity
 };
 
 const mutations = {
   /**
-   * 상태에 카드를 추가한다.
+   * key와 value를 이용해서 상태를 변경한다.
    *
    * @param {object} state
    * @param {object} payload
-   * @param {array} payload.cards
+   * @param {string} payload.key
+   * @param {any} payload.value
    */
-  [ADD_CARDS](state, payload) {
-    state.cards.push(...payload.cards);
+  [SET_VALUE](state, payload) {
+    const { key, value } = payload;
+    state[key] = value;
   }
 };
 
@@ -31,24 +36,63 @@ const actions = {
    * @param {function} param.commit
    * @param {object} param.state
    */
-  async [FETCH_CARDS]({ commit, state }) {
+  async [FETCH_CARDS]({ dispatch, commit, state }) {
     if (state.nextPage > state.lastPage) return;
 
+    await dispatch(FETCH_POSTS);
+
+    const newCards = state.posts.map(post =>
+      makeCard({
+        type: CardType.Post,
+        data: post
+      })
+    );
+
+    commit(SET_VALUE, {
+      key: 'cards',
+      value: [...state.cards, ...newCards]
+    });
+
+    commit(SET_VALUE, {
+      key: 'posts',
+      value: []
+    });
+  },
+
+  /**
+   * 서버로 부터 post를 불러온다.
+   *
+   * @param {object} param
+   * @param {function} param.commit
+   * @param {object} param.state
+   */
+  async [FETCH_POSTS]({ commit, state }) {
     const { data, last_page } = await callApi({
       url: '/api/list',
       params: {
         page: state.nextPage,
         ord: 'asc',
         category: [1, 2, 3],
-        limit: FETCH_CARD_LENGTH
+        limit: FETCH_POST_LENGTH
       }
     });
 
-    state.nextPage = state.nextPage + 1;
-    state.lastPage = last_page;
+    commit(SET_VALUE, {
+      key: 'nextPage',
+      value: state.nextPage + 1
+    });
 
-    commit(ADD_CARDS, {
-      cards: data.map(card => normalizeObjectProperty(card))
+    commit(SET_VALUE, {
+      key: 'lastPage',
+      value: last_page
+    });
+
+    commit(SET_VALUE, {
+      key: 'posts',
+      value: [
+        ...state.posts,
+        ...data.map(post => normalizeObjectProperty(post))
+      ]
     });
   }
 };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,7 @@
 import { createStore } from 'vuex';
 import { callApi } from '../utils/api';
-import { FETCH_CARDS, FETCH_POSTS, SET_VALUE } from './types';
-import { FETCH_POST_LENGTH } from '../constant';
+import { FETCH_ADS, FETCH_CARDS, FETCH_POSTS, SET_VALUE } from './types';
+import { AD_INTERVAL, FETCH_AD_LENGTH, FETCH_POST_LENGTH } from '../constant';
 import { normalizeObjectProperty } from '@/utils/normalize';
 import { CardType } from '../constant';
 import { makeCard } from '../utils/card';
@@ -9,8 +9,17 @@ import { makeCard } from '../utils/card';
 const state = {
   cards: [],
   posts: [],
-  nextPage: 1,
-  lastPage: Infinity
+  ads: [],
+  postNextPage: 1,
+  postLastPage: Infinity,
+  adNextPage: 1,
+  adLastPage: Infinity
+};
+
+const getters = {
+  hasMoreCards(state) {
+    return state.postNextPage <= state.postLastPage;
+  }
 };
 
 const mutations = {
@@ -30,47 +39,58 @@ const mutations = {
 
 const actions = {
   /**
-   * 서버로 부터 카드를 받아온다.
+   * 서버로부터 post와 ad를 받아와 card를 추가한다.
    *
-   * @param {object} param
-   * @param {function} param.commit
-   * @param {object} param.state
+   * @param {object} context
+   * @param {function} context.commit
+   * @param {object} context.state
    */
   async [FETCH_CARDS]({ dispatch, commit, state }) {
-    if (state.nextPage > state.lastPage) return;
-
     await dispatch(FETCH_POSTS);
+    await dispatch(FETCH_ADS);
 
-    const newCards = state.posts.map(post =>
-      makeCard({
-        type: CardType.Post,
-        data: post
-      })
-    );
+    const newCards = [];
 
-    commit(SET_VALUE, {
-      key: 'cards',
-      value: [...state.cards, ...newCards]
+    state.posts.forEach((post, index) => {
+      newCards.push(
+        makeCard({
+          id: `${CardType.Post}-${index}`,
+          type: CardType.Post,
+          data: post
+        })
+      );
+
+      if ((index + 1) % AD_INTERVAL === 0) {
+        newCards.push(
+          makeCard({
+            id: `${CardType.Ad}-${index}`,
+            type: CardType.Ad,
+            data: state.ads[(index + 1) / AD_INTERVAL - 1]
+          })
+        );
+      }
     });
 
     commit(SET_VALUE, {
-      key: 'posts',
-      value: []
+      key: 'cards',
+      value: newCards
     });
   },
 
   /**
    * 서버로 부터 post를 불러온다.
    *
-   * @param {object} param
-   * @param {function} param.commit
-   * @param {object} param.state
+   * @param {object} context
+   * @param {function} context.commit
+   * @param {object} context.state
    */
   async [FETCH_POSTS]({ commit, state }) {
+    if (state.postNextPage > state.postLastPage) return;
+
     const { data, last_page } = await callApi({
       url: '/api/list',
       params: {
-        page: state.nextPage,
+        page: state.postNextPage,
         ord: 'asc',
         category: [1, 2, 3],
         limit: FETCH_POST_LENGTH
@@ -78,12 +98,12 @@ const actions = {
     });
 
     commit(SET_VALUE, {
-      key: 'nextPage',
-      value: state.nextPage + 1
+      key: 'postNextPage',
+      value: state.postNextPage + 1
     });
 
     commit(SET_VALUE, {
-      key: 'lastPage',
+      key: 'postLastPage',
       value: last_page
     });
 
@@ -94,11 +114,46 @@ const actions = {
         ...data.map(post => normalizeObjectProperty(post))
       ]
     });
+  },
+
+  /**
+   * 서버로 부터 ad를 불러온다.
+   *
+   * @param {object} context
+   * @param {function} context.commit
+   * @param {object} context.state
+   */
+  async [FETCH_ADS]({ commit, state }) {
+    if (state.ads.length * AD_INTERVAL >= state.posts.length) return;
+
+    const { data, last_page } = await callApi({
+      url: '/api/ads',
+      params: {
+        page: state.adNextPage,
+        limit: FETCH_AD_LENGTH
+      }
+    });
+
+    commit(SET_VALUE, {
+      key: 'adNextPage',
+      value: state.adNextPage === state.adLastPage ? 1 : state.adNextPage + 1
+    });
+
+    commit(SET_VALUE, {
+      key: 'adLastPage',
+      value: last_page
+    });
+
+    commit(SET_VALUE, {
+      key: 'ads',
+      value: [...state.ads, ...data.map(ad => normalizeObjectProperty(ad))]
+    });
   }
 };
 
 export default createStore({
   state,
+  getters,
   mutations,
   actions
 });

--- a/src/store/types.js
+++ b/src/store/types.js
@@ -1,3 +1,4 @@
 export const SET_VALUE = 'home/setValue';
 export const FETCH_CARDS = 'home/fetchCards';
 export const FETCH_POSTS = 'home/fetchPosts';
+export const FETCH_ADS = 'home/fetchAds';

--- a/src/store/types.js
+++ b/src/store/types.js
@@ -1,2 +1,3 @@
-export const ADD_CARDS = 'home/addCards';
+export const SET_VALUE = 'home/setValue';
 export const FETCH_CARDS = 'home/fetchCards';
+export const FETCH_POSTS = 'home/fetchPosts';

--- a/src/utils/card.js
+++ b/src/utils/card.js
@@ -1,0 +1,21 @@
+import { CardType } from '../constant';
+import { getEnumValues } from './enum';
+
+let cardId = 0;
+
+/**
+ * Card 컴포넌트에 사용되는 card 객체를 생성한다
+ * @param {object} param
+ * @param {CardType.Post | CardType.Ad} param.type
+ * @param {object} param.data
+ * @return {object | undefined}
+ */
+export function makeCard({ type, data }) {
+  if (getEnumValues(CardType).indexOf(type) === -1) return;
+
+  return {
+    id: cardId++,
+    type,
+    data
+  };
+}

--- a/src/utils/card.js
+++ b/src/utils/card.js
@@ -1,20 +1,19 @@
 import { CardType } from '../constant';
 import { getEnumValues } from './enum';
 
-let cardId = 0;
-
 /**
  * Card 컴포넌트에 사용되는 card 객체를 생성한다
  * @param {object} param
+ * @param {number} param.id
  * @param {CardType.Post | CardType.Ad} param.type
  * @param {object} param.data
  * @return {object | undefined}
  */
-export function makeCard({ type, data }) {
+export function makeCard({ id, type, data }) {
   if (getEnumValues(CardType).indexOf(type) === -1) return;
 
   return {
-    id: cardId++,
+    id,
     type,
     data
   };

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -1,0 +1,13 @@
+/**
+ * ISO 문자열 형식의 날짜를 포매팅한다.
+ *
+ * @example
+ * formatISOString('2019-11-11T06:00:49.000000Z');
+ * // returns '2019-11-11';
+ *
+ * @param {string} isoString
+ * @returns {string}
+ */
+export function formatISOString(isoString) {
+  return isoString.substr(0, 10);
+}

--- a/src/utils/enum.js
+++ b/src/utils/enum.js
@@ -1,0 +1,9 @@
+/**
+ * enum 형태의 객체의 값들을 배열로 반환한다.
+ *
+ * @param {object} enumObject
+ * @returns {array}
+ */
+export function getEnumValues(enumObject) {
+  return Object.keys(enumObject).map(key => enumObject[key]);
+}


### PR DESCRIPTION
# 요약
4번째 마다 광고를 삽입하는 기능 추가

# PR 상세

## 1) Card 컴포넌트 타입 나누기(Post, Ad)
광고 추가로 인해 카드 컴포넌트는 Post와 Ad 두 가지의 타입을 가집니다. props의 type을 이용해 원하는 타입의 Card를 사용할 수 있습니다.
```js
<Card type="post" />
```
또한 Vuex에 저장되는 cards 배열의 객체 형식도 변경되었습니다.
```typescript
interface Card {
  id: string;
  type: 'post' | 'ad';
  data: object;
}
```

## 2) 광고 불러오는 api 추가
fetchCards 액션이 fetchPosts와 fetchAds를 dispatch 하도록 만들고, 불러온 posts, ads를 이용해 n번째 마다 광고 타입의 카드가 삽입된 형태의 cards 상태를 생성하도록 하였습니다.
