### PR TITLE
리팩토링 진행

### DIFF
--- a/src/components/CardList.vue
+++ b/src/components/CardList.vue
@@ -1,43 +1,28 @@
 <template>
-  <div class="card-container">
-    <CardContainerHeader />
-    <Card
+  <div class="card-list">
+    <CardListItem
       v-for="card in cards"
       :key="card.id"
       :type="card.type"
       :data="card.data"
       @click="goToDetail(card)"
     />
-    <InfiniteScroll v-if="hasMoreCards" @load="fetchCards" />
   </div>
 </template>
 
 <script>
-import CardContainerHeader from '@/components/CardContainerHeader.vue';
-import Card from '@/components/Card.vue';
-import InfiniteScroll from '@/components/InfiniteScroll.vue';
-import { mapActions, mapGetters, mapState } from 'vuex';
-import { FETCH_CARDS } from '@/store/modules/home/types';
+import CardListItem from '@/components/CardListItem.vue';
 import { CardType } from '@/constant';
 
 export default {
-  name: 'CardContainer',
+  name: 'CardList',
   components: {
-    CardContainerHeader,
-    Card,
-    InfiniteScroll
+    CardListItem
   },
-  computed: {
-    ...mapState({
-      cards: state => state.home.cards
-    }),
-    ...mapGetters(['hasMoreCards'])
+  props: {
+    cards: Array
   },
   methods: {
-    ...mapActions({
-      fetchCards: FETCH_CARDS
-    }),
-
     /**
      * 카드의 타입이 post일 경우 상세 페이지로 이동한다.
      *
@@ -55,9 +40,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.card-container {
+.card-list {
   float: right;
-  width: $card-container-width;
+  width: $card-list-width;
 
   @media (max-width: $layout-breakpoint-mobile) {
     width: 100%;

--- a/src/components/CardListHeader.vue
+++ b/src/components/CardListHeader.vue
@@ -1,28 +1,29 @@
 <template>
-  <div class="card-container-header">
-    <SortOptionContainer
+  <div class="card-list-header">
+    <SortOptionList
       :options="sortOptions"
       :selectedValue="ord"
-      @select="fetchUpdateOrd($event)"
+      @select="sort"
     />
-    <button class="card-container-header__filter-button" @click="openModal">
+    <button class="card-list-header__filter-button" @click="openModal">
       필터
     </button>
   </div>
 </template>
 
 <script>
-import SortOptionContainer from '@/components/SortOptionContainer.vue';
+import SortOptionList from '@/components/SortOptionList.vue';
 import { SortOptions, SORT_OPTIONS_NAME_MAP } from '@/constant';
 import { getEnumValues } from '@/utils/enum';
-import { mapActions, mapMutations, mapState } from 'vuex';
-import { FETCH_UPDATE_ORD, OPEN_MODAL } from '@/store/modules/home/types';
+import { mapMutations, mapState } from 'vuex';
+import { OPEN_MODAL, SET_VALUE } from '@/store/modules/home/types';
 
 export default {
-  name: 'CardContainerHeader',
+  name: 'CardListHeader',
   components: {
-    SortOptionContainer
+    SortOptionList
   },
+  emits: ['orderchange'],
   data() {
     return {
       sortOptions: getEnumValues(SortOptions).map(sortOption => ({
@@ -38,36 +39,54 @@ export default {
   },
   methods: {
     ...mapMutations({
+      setValue: SET_VALUE,
       openModal: OPEN_MODAL
     }),
-    ...mapActions({
-      fetchUpdateOrd: FETCH_UPDATE_ORD
-    })
+
+    /**
+     * 정렬 순서 상태를 변경하고 이벤트를 발생시킨다.
+     *
+     * @param {'asc' | 'desc'} ord
+     */
+    sort(ord) {
+      if (this.ord === ord) return;
+
+      this.setValue({
+        key: 'ord',
+        value: ord
+      });
+      this.$emit('orderchange');
+    }
   }
 };
 </script>
 
 <style lang="scss" scoped>
-.card-container-header {
-  height: $card-container-header-height;
+.card-list-header {
+  float: right;
+  width: $card-list-width;
+  height: $card-list-header-height;
   margin-bottom: 11px;
   overflow: hidden;
   background-color: #fff;
 
   @media (max-width: $layout-breakpoint-mobile) {
+    box-sizing: border-box;
+    width: 100%;
+    height: 44px;
     padding: 10px 15px 10px 18px;
     border-bottom: 1px solid #e1e4e7;
     margin-bottom: 0px;
   }
 }
 
-.card-container-header__filter-button {
+.card-list-header__filter-button {
   float: right;
   display: flex;
   justify-content: center;
   align-items: center;
   width: 48px;
-  height: $card-container-header-height;
+  height: $card-list-header-height;
   padding: 0px;
   margin: 0px;
   font-size: 13px;

--- a/src/components/CardListItem.vue
+++ b/src/components/CardListItem.vue
@@ -12,7 +12,7 @@ import { CardType } from '../constant';
 import { getEnumValues } from '../utils/enum';
 
 export default {
-  name: 'Card',
+  name: 'CardListItem',
   components: {
     Post,
     Ad

--- a/src/components/InfiniteScroll.vue
+++ b/src/components/InfiniteScroll.vue
@@ -42,6 +42,7 @@ function getIntersectionOberserver(callback, options = {}) {
 
 <style lang="scss" scoped>
 .infinite-scroll {
+  float: left;
   width: 100%;
   height: 10px;
   background: transparent;

--- a/src/components/SortOptionList.vue
+++ b/src/components/SortOptionList.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="sort-option-container">
-    <SortOption
+  <div class="sort-option-list">
+    <SortOptionListItem
       v-for="option in options"
       :key="option.value"
       :value="option.value"
@@ -12,12 +12,12 @@
 </template>
 
 <script>
-import SortOption from '@/components/SortOption.vue';
+import SortOptionListItem from '@/components/SortOptionListItem.vue';
 
 export default {
-  name: 'SortOptionContainer',
+  name: 'SortOptionList',
   components: {
-    SortOption
+    SortOptionListItem
   },
   props: {
     options: Array,
@@ -32,10 +32,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.sort-option-container {
+.sort-option-list {
   display: flex;
   align-items: center;
-  height: $card-container-header-height;
+  height: $card-list-header-height;
   float: left;
 }
 </style>

--- a/src/components/SortOptionListItem.vue
+++ b/src/components/SortOptionListItem.vue
@@ -7,7 +7,7 @@
 
 <script>
 export default {
-  name: 'SortOption',
+  name: 'SortOptionListItem',
   props: {
     title: String,
     value: String,

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,9 +1,9 @@
 $main-color: #00c854;
 $main-width: 1140px;
 $user-width: 235px;
-$card-container-width: 865px;
+$card-list-width: 865px;
 $card-border-color: #e1e4e7;
-$card-container-header-height: 24px;
+$card-list-header-height: 24px;
 
 /* 반응형 레이아웃 breakpoint */
 $layout-breakpoint-mobile: 768px;

--- a/src/store/modules/home/index.js
+++ b/src/store/modules/home/index.js
@@ -5,7 +5,6 @@ import {
   FETCH_CARDS,
   FETCH_CATEGORY,
   FETCH_POSTS,
-  FETCH_UPDATE_ORD,
   INITIALIZE_CARDS,
   OPEN_MODAL,
   SET_VALUE
@@ -14,13 +13,11 @@ import {
   AD_INTERVAL,
   FETCH_AD_LENGTH,
   FETCH_POST_LENGTH,
-  SortOptions,
-  FETCH_CARD_DELAY
+  SortOptions
 } from '@/constant';
 import { normalizeObjectProperty } from '@/utils/normalize';
 import { CardType } from '@/constant';
 import { makeCard } from '@/utils/card';
-import { debounce } from '@/utils/function';
 
 const INITIAL_STATE = {
   cards: [],
@@ -204,26 +201,6 @@ const actions = {
   },
 
   /**
-   * 정렬 순서를 변경한 후 다시 card를 로드한다
-   *
-   * @param {object} context
-   * @param {function} context.dispatch
-   * @param {function} context.commit
-   * @param {object} context.state
-   * @param {string} value SortOptions enum의 값
-   */
-  async [FETCH_UPDATE_ORD]({ dispatch, commit, state }, value) {
-    if (state.ord === value) return;
-
-    commit(SET_VALUE, {
-      key: 'ord',
-      value
-    });
-    commit(INITIALIZE_CARDS);
-    await dispatch(FETCH_CARDS);
-  },
-
-  /**
    * category를 불러온 뒤 기본 설정된 카테고리 필터값을 저장한다.
    *
    * @param {object} context
@@ -251,8 +228,5 @@ export default {
   state: { ...INITIAL_STATE },
   getters,
   mutations,
-  actions: {
-    ...actions,
-    [FETCH_CARDS]: debounce(actions[FETCH_CARDS], FETCH_CARD_DELAY)
-  }
+  actions
 };

--- a/src/store/modules/home/index.js
+++ b/src/store/modules/home/index.js
@@ -29,13 +29,16 @@ const INITIAL_STATE = {
   adLastPage: Infinity,
   ord: SortOptions.ASC,
   isModalVisible: false,
-  category: null,
+  category: [],
   filteredCategoryIds: null
 };
 
 const getters = {
   hasMoreCards(state) {
     return state.postNextPage <= state.postLastPage;
+  },
+  isCardEmpty(state) {
+    return state.cards.length === 0;
   }
 };
 

--- a/src/store/modules/home/types.js
+++ b/src/store/modules/home/types.js
@@ -2,7 +2,6 @@ export const SET_VALUE = 'home/setValue';
 export const FETCH_CARDS = 'home/fetchCards';
 export const FETCH_POSTS = 'home/fetchPosts';
 export const FETCH_ADS = 'home/fetchAds';
-export const FETCH_UPDATE_ORD = 'home/fetchUpdateOrd';
 export const INITIALIZE_CARDS = 'home/initializeCards';
 export const OPEN_MODAL = 'home/openModal';
 export const CLOSE_MODAL = 'home/closeModal';

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -43,7 +43,7 @@ export default {
     ...mapState({
       cards: state => state.home.cards
     }),
-    ...mapGetters(['hasMoreCards'])
+    ...mapGetters(['hasMoreCards', 'isCardEmpty'])
   },
   methods: {
     ...mapMutations({
@@ -74,7 +74,11 @@ export default {
   created() {
     this.debouncedFetchCards = debounce(this.fetchCards, FETCH_CARD_DELAY);
     this.fetchCategory();
-    this.debouncedFetchCards();
+
+    // 카드가 비어있으면 카드를 불러온다.
+    if (this.isCardEmpty) {
+      this.debouncedFetchCards();
+    }
   }
 };
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,7 +3,9 @@
     <Header title="[2020-12-29] 천영도" />
     <Content>
       <User />
-      <CardContainer />
+      <CardListHeader @orderchange="onOrderChange" />
+      <CardList :cards="cards" />
+      <InfiniteScroll v-if="hasMoreCards" @load="debouncedFetchCards" />
     </Content>
     <Filter @save="onFilterSave" />
   </div>
@@ -13,14 +15,18 @@
 import Header from '@/components/Header.vue';
 import Content from '@/components/Content.vue';
 import User from '@/components/User.vue';
-import CardContainer from '@/components/CardContainer.vue';
+import CardListHeader from '@/components/CardListHeader.vue';
+import CardList from '@/components/CardList.vue';
+import InfiniteScroll from '@/components/InfiniteScroll.vue';
 import Filter from '@/components/Filter.vue';
-import { mapActions, mapMutations } from 'vuex';
+import { mapActions, mapGetters, mapMutations, mapState } from 'vuex';
 import {
   FETCH_CARDS,
   FETCH_CATEGORY,
   INITIALIZE_CARDS
 } from '@/store/modules/home/types';
+import { debounce } from '@/utils/function';
+import { FETCH_CARD_DELAY } from '@/constant';
 
 export default {
   name: 'Home',
@@ -28,8 +34,16 @@ export default {
     Header,
     Content,
     User,
-    CardContainer,
+    CardListHeader,
+    CardList,
+    InfiniteScroll,
     Filter
+  },
+  computed: {
+    ...mapState({
+      cards: state => state.home.cards
+    }),
+    ...mapGetters(['hasMoreCards'])
   },
   methods: {
     ...mapMutations({
@@ -46,11 +60,21 @@ export default {
      */
     onFilterSave() {
       this.initializeCards();
-      this.fetchCards();
+      this.debouncedFetchCards();
+    },
+
+    /**
+     * 변경된 순서를 이용해서 cards를 다시 불러온다
+     */
+    onOrderChange() {
+      this.initializeCards();
+      this.debouncedFetchCards();
     }
   },
   created() {
+    this.debouncedFetchCards = debounce(this.fetchCards, FETCH_CARD_DELAY);
     this.fetchCategory();
+    this.debouncedFetchCards();
   }
 };
 </script>


### PR DESCRIPTION
# 요약
Home 컴포넌트와 관련된 리팩토링 수행

# PR 상세
## 1) container 컴포넌트와 presentation 컴포넌트 분리
Home의 하위 컴포넌트에서 side-effect가 발생하던 것을 대부분 Home 컴포넌트로 이동하였습니다. 이로서 Home 컴포넌트는 container 컴포넌트의 역할을 하며, 하위 컴포넌트들은 대부분 presentation 컴포넌트로 만들었습니다(아직 일부 컴포넌트는 container 역할을 함 -  CardListHeader).

## 2) 컴포넌트 이름 변경
Vue의 스타일 가이드를 따라 일부 컴포넌트의 이름을 변경하였습니다.
- CardContainer → CardList
- Card → CardListItem
- CardContainerHeader → CardListHeader
- SortOptionContainer → SortOptionList
- SortOption → SortOptionsListItem