### PR TITLE
Fix: 초기 페이지 로딩 시 피드를 제대로 불러오지 않는 버그 수정

### DIFF
--- a/src/components/Filter.vue
+++ b/src/components/Filter.vue
@@ -39,9 +39,11 @@ export default {
       filteredCategoryIds: state => state.home.filteredCategoryIds
     }),
     categoryNames() {
+      if (!this.category) return [];
       return this.category.map(item => item.name);
     },
     filteredCategoryNames() {
+      if (!this.category) return [];
       return this.category
         .filter(item => this.filteredCategoryIds.indexOf(item.id) !== -1)
         .map(item => item.name);
@@ -56,6 +58,7 @@ export default {
      * 선택된 카테고리의 id를 저장하고 모달을 닫는다.
      */
     onConfirm() {
+      if (!this.category) return;
       const filteredCategoryNames = this.values
         ? [...this.values]
         : [...this.filteredCategoryNames];

--- a/src/store/modules/home/index.js
+++ b/src/store/modules/home/index.js
@@ -29,7 +29,7 @@ const INITIAL_STATE = {
   adLastPage: Infinity,
   ord: SortOptions.ASC,
   isModalVisible: false,
-  category: [],
+  category: null,
   filteredCategoryIds: null
 };
 
@@ -99,6 +99,7 @@ const actions = {
    * @param {object} context.state
    */
   async [FETCH_CARDS]({ dispatch, commit, state }) {
+    await dispatch(FETCH_CATEGORY);
     await dispatch(FETCH_POSTS);
     await dispatch(FETCH_ADS);
 
@@ -211,6 +212,8 @@ const actions = {
    * @param {function} context.state
    */
   async [FETCH_CATEGORY]({ commit, state }) {
+    if (state.category) return;
+
     const { category } = await callApi({
       url: '/api/category'
     });
@@ -222,7 +225,7 @@ const actions = {
 
     commit(SET_VALUE, {
       key: 'filteredCategoryIds',
-      value: state.filteredCategoryIds || category.map(item => item.id)
+      value: category.map(item => item.id)
     });
   }
 };

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -20,11 +20,7 @@ import CardList from '@/components/CardList.vue';
 import InfiniteScroll from '@/components/InfiniteScroll.vue';
 import Filter from '@/components/Filter.vue';
 import { mapActions, mapGetters, mapMutations, mapState } from 'vuex';
-import {
-  FETCH_CARDS,
-  FETCH_CATEGORY,
-  INITIALIZE_CARDS
-} from '@/store/modules/home/types';
+import { FETCH_CARDS, INITIALIZE_CARDS } from '@/store/modules/home/types';
 import { debounce } from '@/utils/function';
 import { FETCH_CARD_DELAY } from '@/constant';
 
@@ -51,8 +47,7 @@ export default {
     }),
 
     ...mapActions({
-      fetchCards: FETCH_CARDS,
-      fetchCategory: FETCH_CATEGORY
+      fetchCards: FETCH_CARDS
     }),
 
     /**
@@ -73,7 +68,6 @@ export default {
   },
   created() {
     this.debouncedFetchCards = debounce(this.fetchCards, FETCH_CARD_DELAY);
-    this.fetchCategory();
 
     // 카드가 비어있으면 카드를 불러온다.
     if (this.isCardEmpty) {


### PR DESCRIPTION
# 요약
홈페이지에서 피드를 제대로 불러오지 못하는 버그 수정
# PR 상세
category 응답보다 card 요청을 먼저 하는 경우 url의 querystring에 category가 들어가지 않아 올바른 응답이 오지 않았다.
card를 요청하는 Action 내부에서 category를 불러올 수 있도록 변경